### PR TITLE
feat: アクティブなエディタなしで拡張機能を実行可能にする

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,23 +24,13 @@ export function activate(context: vscode.ExtensionContext) {
         .getConfiguration("commiter")
         .get("customInstruction") as string;
 
-      // アクティブなエディタを取得
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        vscode.window.showErrorMessage("アクティブなエディタがありません");
-        return;
-      }
-
       try {
-        const uri = vscode.workspace.getWorkspaceFolder(
-          editor.document.uri
-        )?.uri;
-        if (!uri) {
-          vscode.window.showErrorMessage(
-            "ワークスペースフォルダが見つかりません"
-          );
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+          vscode.window.showErrorMessage("ワークスペースフォルダが見つかりません");
           return;
         }
+        const uri = workspaceFolders[0].uri;
         // ステージングされた差分を取得
         const { stdout: gitDiff } = await execAsync("git diff --staged", {
           cwd: uri.fsPath,


### PR DESCRIPTION
これまで拡張機能の実行にはアクティブなテキストエディタが必要でしたが、
この変更により、ワークスペースが開かれていればアクティブなエディタがなくても
`commiter.generateCommitMessage` コマンドを実行できるようになります。

変更点:
- アクティブなエディタの存在確認処理を削除しました。
- ワークスペースフォルダのURI取得方法を `vscode.window.activeTextEditor` への依存から `vscode.workspace.workspaceFolders` を使用する形に変更しました。
- ワークスペースが開かれていない場合は、適切なエラーメッセージを表示します。

テストケース:
- アクティブなエディタなし、ワークスペースあり: 動作確認済み
- ワークスペースなし: エラーメッセージ表示確認済み
- アクティブなエディタあり、ワークスペースあり（既存機能）: 動作確認済み